### PR TITLE
Changed heading from button to div

### DIFF
--- a/src/components/heading.tsx
+++ b/src/components/heading.tsx
@@ -33,15 +33,10 @@ const Heading: React.FC<HeadingProps> = ({
   const open = useMemo(() => openedItems?.includes(uid), [openedItems, uid]);
 
   return (
-    <button
+    <div
       onClick={toggleOpen}
       className={className}
-      style={{
-        appearance: `none`,
-        backgroundColor: `transparent`,
-        border: 0,
-        ...style,
-      }}
+      style={style}
     >
       {typeof children === `function` ? children(open) : children}
     </button>


### PR DESCRIPTION
Using a button object makes it more difficult to apply custom stylings to the heading, and the default style seemed to override those applied by a className defined in a separate CSS file.